### PR TITLE
Rotate front and left facing UVs -90 degrees

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,11 +131,20 @@ Mesh.prototype.faceVertexUv = function(i) {
       var height = size.x
     }
   }
-  return [
-    new THREE.Vector2(0, 0),
-    new THREE.Vector2(0, height),
-    new THREE.Vector2(width, height),
-    new THREE.Vector2(width, 0)
-  ]
+  if ((size.z === 0 && spans.x0 < spans.x1) || (size.x === 0 && spans.y0 > spans.y1)) {
+    return [
+      new THREE.Vector2(height, 0),
+      new THREE.Vector2(0, 0),
+      new THREE.Vector2(0, width),
+      new THREE.Vector2(height, width)
+    ]
+  } else {
+    return [
+      new THREE.Vector2(0, 0),
+      new THREE.Vector2(0, height),
+      new THREE.Vector2(width, height),
+      new THREE.Vector2(width, 0)
+    ]
+  }
 }
 ;


### PR DESCRIPTION
Currently in voxel-texture I am [rotating the front and left textures 90 degrees](https://github.com/shama/voxel-texture/blob/master/index.js#L45) when loading a texture onto a mesh to compensate for the UVs.

I think it would be more efficient to rotate the UVs on the mesh instead. This change will return UVs rotated -90 degrees for the front and left faces. Thanks!
