### PR TITLE
Fix argument order when calling Mesh constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var THREE = require('three')
 
-module.exports = function(data, scaleFactor, mesher) {
-  return new Mesh(data, scaleFactor, mesher)
+module.exports = function(data, mesher, scaleFactor) {
+  return new Mesh(data, mesher, scaleFactor)
 }
 
 module.exports.Mesh = Mesh


### PR DESCRIPTION
Constructor looks like this

```
function Mesh(data, mesher, scaleFactor) {
```

But it was called like this

```
module.exports = function(data, scaleFactor, mesher) {
  return new Mesh(data, scaleFactor, mesher)
}
```
