### PR TITLE
Add an option to supply a THREE.js instance to the Mesh constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,16 @@
 var THREE = require('three')
 
-module.exports = function(data, mesher, scaleFactor) {
-  return new Mesh(data, mesher, scaleFactor)
+module.exports = function(data, mesher, scaleFactor, three) {
+  return new Mesh(data, mesher, scaleFactor, three)
 }
 
 module.exports.Mesh = Mesh
 
-function Mesh(data, mesher, scaleFactor) {
+function Mesh(data, mesher, scaleFactor, three) {
+  this.THREE = three || THREE
   this.data = data
-  var geometry = this.geometry = new THREE.Geometry()
-  this.scale = scaleFactor || new THREE.Vector3(10, 10, 10)
+  var geometry = this.geometry = new this.THREE.Geometry()
+  this.scale = scaleFactor || new this.THREE.Vector3(10, 10, 10)
   
   var result = mesher( data.voxels, data.dims )
   this.meshed = result
@@ -19,7 +20,7 @@ function Mesh(data, mesher, scaleFactor) {
 
   for (var i = 0; i < result.vertices.length; ++i) {
     var q = result.vertices[i]
-    geometry.vertices.push(new THREE.Vector3(q[0], q[1], q[2]))
+    geometry.vertices.push(new this.THREE.Vector3(q[0], q[1], q[2]))
   } 
   
   for (var i = 0; i < result.faces.length; ++i) {
@@ -27,13 +28,13 @@ function Mesh(data, mesher, scaleFactor) {
     
     var q = result.faces[i]
     if (q.length === 5) {
-      var f = new THREE.Face4(q[0], q[1], q[2], q[3])
-      f.color = new THREE.Color(q[4])
+      var f = new this.THREE.Face4(q[0], q[1], q[2], q[3])
+      f.color = new this.THREE.Color(q[4])
       f.vertexColors = [f.color,f.color,f.color,f.color]
       geometry.faces.push(f)
     } else if (q.length == 4) {
-      var f = new THREE.Face3(q[0], q[1], q[2])
-      f.color = new THREE.Color(q[3])
+      var f = new this.THREE.Face3(q[0], q[1], q[2])
+      f.color = new this.THREE.Color(q[3])
       f.vertexColors = [f.color,f.color,f.color]
       geometry.faces.push(f)
     }
@@ -51,7 +52,7 @@ function Mesh(data, mesher, scaleFactor) {
 }
 
 Mesh.prototype.createWireMesh = function(hexColor) {    
-  var wireMaterial = new THREE.MeshBasicMaterial({
+  var wireMaterial = new this.THREE.MeshBasicMaterial({
     color : hexColor || 0xffffff,
     wireframe : true
   })
@@ -63,8 +64,8 @@ Mesh.prototype.createWireMesh = function(hexColor) {
 }
 
 Mesh.prototype.createSurfaceMesh = function(material) {
-  material = material || new THREE.MeshNormalMaterial()
-  var surfaceMesh  = new THREE.Mesh( this.geometry, material )
+  material = material || new this.THREE.MeshNormalMaterial()
+  var surfaceMesh  = new this.THREE.Mesh( this.geometry, material )
   surfaceMesh.scale = this.scale
   surfaceMesh.doubleSided = false
   this.surfaceMesh = surfaceMesh
@@ -77,8 +78,8 @@ Mesh.prototype.addToScene = function(scene) {
 }
 
 Mesh.prototype.setPosition = function(x, y, z) {
-  if (this.wireMesh) this.wireMesh.position = new THREE.Vector3(x, y, z)
-  if (this.surfaceMesh) this.surfaceMesh.position = new THREE.Vector3(x, y, z)
+  if (this.wireMesh) this.wireMesh.position = new this.THREE.Vector3(x, y, z)
+  if (this.surfaceMesh) this.surfaceMesh.position = new this.THREE.Vector3(x, y, z)
 }
 
 Mesh.prototype.faceVertexUv = function(i) {
@@ -133,17 +134,17 @@ Mesh.prototype.faceVertexUv = function(i) {
   }
   if ((size.z === 0 && spans.x0 < spans.x1) || (size.x === 0 && spans.y0 > spans.y1)) {
     return [
-      new THREE.Vector2(height, 0),
-      new THREE.Vector2(0, 0),
-      new THREE.Vector2(0, width),
-      new THREE.Vector2(height, width)
+      new this.THREE.Vector2(height, 0),
+      new this.THREE.Vector2(0, 0),
+      new this.THREE.Vector2(0, width),
+      new this.THREE.Vector2(height, width)
     ]
   } else {
     return [
-      new THREE.Vector2(0, 0),
-      new THREE.Vector2(0, height),
-      new THREE.Vector2(width, height),
-      new THREE.Vector2(width, 0)
+      new this.THREE.Vector2(0, 0),
+      new this.THREE.Vector2(0, height),
+      new this.THREE.Vector2(width, height),
+      new this.THREE.Vector2(width, 0)
     ]
   }
 }


### PR DESCRIPTION
Because transitive dependencies get inserted in to the browserify bundle multiple times (see https://github.com/substack/node-browserify/issues/186) THREE.js can get loaded and instantiated multiple times in a single voxel-engine app.

This causes problems because for example `instanceof` checks fail for objects created in one Three instance and passed to another. 

In my case

``` javascript
var mesh = new Mesh(voxelData);
game.scene.add(mesh.createSurfaceMesh());
```

Fails because the

``` javascript
mesh instanceof Object3d
```

fails inside Three.js
