### PR TITLE
Compute vertex colors for ambient occlusion.

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,17 +30,34 @@ function Mesh(data, mesher, scaleFactor, three) {
     if (q.length === 5) {
       var f = new this.THREE.Face4(q[0], q[1], q[2], q[3])
       f.color = new this.THREE.Color(q[4])
-      f.vertexColors = [f.color,f.color,f.color,f.color]
       geometry.faces.push(f)
     } else if (q.length == 4) {
       var f = new this.THREE.Face3(q[0], q[1], q[2])
       f.color = new this.THREE.Color(q[3])
-      f.vertexColors = [f.color,f.color,f.color]
       geometry.faces.push(f)
     }
   }
   
   geometry.computeFaceNormals()
+
+  // compute vertex colors for ambient occlusion
+  var light = new THREE.Color(0xffffff)
+  var shadow = new THREE.Color(0x505050)
+  for (var i = 0; i < geometry.faces.length; ++i) {
+    var face = geometry.faces[i]
+    // facing up
+    if (face.normal.y === 1)       face.vertexColors = [light, light, light, light]
+    // facing down
+    else if (face.normal.y === -1) face.vertexColors = [shadow, shadow, shadow, shadow]
+    // facing right
+    else if (face.normal.x === 1)  face.vertexColors = [shadow, light, light, shadow]
+    // facing left
+    else if (face.normal.x === -1) face.vertexColors = [shadow, shadow, light, light]
+    // facing backward
+    else if (face.normal.z === 1)  face.vertexColors = [shadow, shadow, light, light]
+    // facing forward
+    else                           face.vertexColors = [shadow, light, light, shadow]
+  }
 
   geometry.verticesNeedUpdate = true
   geometry.elementsNeedUpdate = true


### PR DESCRIPTION
Its not perfect but a little closer. If two voxels are stacked on each other it's a little off. There is probably a correct way to better compute ambient occlusion. This probably should become it's own module as well. With more enhancements I imagine it could become quite involved, i.e.: simulate shadowing on neighbor voxels, adjusting the light/shadow based on the type of voxel, etc.

![voxel](https://gist.github.com/shama/5210665/raw/eb0bf09c92fbe3fc0e9b01bbb40f98ae5ecf26b3/screen_2013-03-20.png)

`voxel-texture` has been updated to paint materials based on `face.color` rather than `face.vertexColors[0]` to support this: shama/voxel-texture@6043b494a359d59026edcaf307975547f56214ca and published as `voxel-texture@0.3.2`

I'll keep at it, fun stuff. Thanks!

Ref GH-6
