### PR TITLE
Change to use Face3 to remove Face4 three.js deprecated usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,13 +6,13 @@ module.exports = function(data, mesher, scaleFactor, three) {
 
 module.exports.Mesh = Mesh
 
-function Mesh(data, mesher, scaleFactor, three) {
+function Mesh(data, mesher, scaleFactor, three, mesherExtraData) {
   this.THREE = three || THREE
   this.data = data
   var geometry = this.geometry = new this.THREE.Geometry()
   this.scale = scaleFactor || new this.THREE.Vector3(10, 10, 10)
   
-  var result = mesher( data.voxels, data.dims )
+  var result = mesher( data.voxels, data.dims, mesherExtraData )
   this.meshed = result
 
   geometry.vertices.length = 0

--- a/index.js
+++ b/index.js
@@ -24,17 +24,24 @@ function Mesh(data, mesher, scaleFactor, three, mesherExtraData) {
   } 
   
   for (var i = 0; i < result.faces.length; ++i) {
-    geometry.faceVertexUvs[0].push(this.faceVertexUv(i))
-    
     var q = result.faces[i]
     if (q.length === 5) {
-      var f = new this.THREE.Face4(q[0], q[1], q[2], q[3])
+      var uv = this.faceVertexUv(i)
+
+      var f = new this.THREE.Face3(q[0], q[1], q[3])
       f.color = new this.THREE.Color(q[4])
       geometry.faces.push(f)
+      geometry.faceVertexUvs[0].push([uv[0], uv[1], uv[3]])
+
+      var g = new this.THREE.Face3(q[1], q[2], q[3])
+      g.color = new this.THREE.Color(q[4])
+      geometry.faces.push(g)
+      geometry.faceVertexUvs[0].push([uv[1], uv[2], uv[3]])
     } else if (q.length == 4) {
       var f = new this.THREE.Face3(q[0], q[1], q[2])
       f.color = new this.THREE.Color(q[3])
       geometry.faces.push(f)
+      geometry.faceVertexUvs[0].push(this.faceVertexUv(i))
     }
   }
   

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var THREE = require('three')
 
-module.exports = function(data, mesher, scaleFactor, three) {
-  return new Mesh(data, mesher, scaleFactor, three)
+module.exports = function(data, mesher, scaleFactor, three, mesherExtraData) {
+  return new Mesh(data, mesher, scaleFactor, three, mesherExtraData)
 }
 
 module.exports.Mesh = Mesh

--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "email": "max@maxogden.com"
   },
   "license": "MIT",
-  "peerDependencies": {
-    "three": "*"
-  },
   "engine": {
     "node": ">=0.6.0"
   }


### PR DESCRIPTION
Closes https://github.com/maxogden/voxel-mesh/issues/13. This is compatible with both three.js 0.58 (as before) and 0.66 (which removed `Face4`).

(also, unrelated: adds the `mesherExtraData` argument for https://github.com/maxogden/voxel/issues/16)
